### PR TITLE
Add custom command support

### DIFF
--- a/eufy_robovac/robovac.py
+++ b/eufy_robovac/robovac.py
@@ -86,6 +86,16 @@ class Robovac(TuyaDevice):
     BATTERY_LEVEL = '104'
     ERROR_CODE = '106'
 
+    COMMAND_DPS = {
+        'power': POWER,
+        'play_pause': PLAY_PAUSE,
+        'direction': DIRECTION,
+        'work_mode': WORK_MODE,
+        'go_home': GO_HOME,
+        'clean_speed': CLEAN_SPEED,
+        'find_robot': FIND_ROBOT,
+    }
+
     power = DeviceProperty(POWER)
     play_pause = DeviceProperty(PLAY_PAUSE)
     direction = DeviceProperty(DIRECTION)
@@ -117,3 +127,7 @@ class Robovac(TuyaDevice):
 
     async def async_set_clean_speed(self, clean_speed, callback=None):
         await self.async_set({self.CLEAN_SPEED: str(clean_speed)}, callback)
+
+    async def async_send_command(self, command, params=None, callback=None):
+        command = self.COMMAND_DPS.get(command, command)
+        await self.async_set({command: str(params[0])}, callback)

--- a/eufy_robovac/vacuum.py
+++ b/eufy_robovac/vacuum.py
@@ -7,7 +7,7 @@ from homeassistant.components.vacuum import (
     STATE_ERROR,
     SUPPORT_BATTERY, SUPPORT_CLEAN_SPOT, SUPPORT_FAN_SPEED, SUPPORT_LOCATE,
     SUPPORT_PAUSE, SUPPORT_RETURN_HOME, SUPPORT_STATUS, SUPPORT_START,
-    SUPPORT_TURN_ON, SUPPORT_TURN_OFF,
+    SUPPORT_TURN_ON, SUPPORT_TURN_OFF, SUPPORT_SEND_COMMAND,
     VacuumEntity)
 
 
@@ -31,7 +31,7 @@ FAN_SPEEDS = {
 SUPPORT_ROBOVAC_T2118 = (
     SUPPORT_BATTERY | SUPPORT_CLEAN_SPOT | SUPPORT_FAN_SPEED | SUPPORT_LOCATE |
     SUPPORT_PAUSE | SUPPORT_RETURN_HOME | SUPPORT_START | SUPPORT_STATUS |
-    SUPPORT_TURN_OFF | SUPPORT_TURN_ON
+    SUPPORT_TURN_OFF | SUPPORT_TURN_ON | SUPPORT_SEND_COMMAND
 )
 
 
@@ -179,3 +179,7 @@ class EufyVacuum(VacuumEntity):
             await self.async_pause()
         else:
             await self.async_play()
+
+    async def async_send_command(self, command, params, **kwargs):
+        """Send a custom command."""
+        await self.robovac.async_send_command(command, params)


### PR DESCRIPTION
I currently can control my vacuum manually with the remote but not from Home Assistant. I added the possibility to send a custom command in order to do this. Now you can control the vacuum by calling the send command service, see example to move the vacuum forward:

<img width="950" alt="Screenshot 2022-05-13 at 22 43 54" src="https://user-images.githubusercontent.com/5374768/168393498-68df42cf-65ec-4abf-b1a3-67bfbaa66978.png">


This is useful not only for this purpose but to send any command that is not standard to the Home Assistant vacuum device.


Note: The reason I want this is because I will attach a camera and let people move my vacuum remotely.